### PR TITLE
(GH-40) updated CakeContrib.Guidelines

### DIFF
--- a/src/Cake.IntelliJ.Recipe/Cake.IntelliJ.Recipe.csproj
+++ b/src/Cake.IntelliJ.Recipe/Cake.IntelliJ.Recipe.csproj
@@ -24,7 +24,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="CakeContrib.Guidelines" Version="1.1.0">
+        <PackageReference Include="CakeContrib.Guidelines" Version="1.1.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
to version 1.1.1, which fixes the detection of recipe
ProjectTypes

fixes #40 