### PR TITLE
(#119) add parameter: intelliJAnalyzerTasks

### DIFF
--- a/src/Cake.IntelliJ.Recipe/Content/analyzing.cake
+++ b/src/Cake.IntelliJ.Recipe/Content/analyzing.cake
@@ -12,9 +12,7 @@ BuildParameters.Tasks.AnalyzeTask = Task("IntelliJAnalyze")
         .FromPath(BuildParameters.SourceDirectoryPath)
         .WithLogLevel(IntelliJBuildParameters.GradleVerbosity)
         .WithProjectProperty("pluginVersion", buildVersion.SemVersion)
-        .WithTask("detekt")
-        .WithTask("ktlintCheck")
-        .WithTask("verifyPlugin")
+        .WithTask(IntelliJBuildParameters.IntelliJAnalyzerTasks)
         .Run();
 });
 

--- a/src/Cake.IntelliJ.Recipe/Content/parameters.cake
+++ b/src/Cake.IntelliJ.Recipe/Content/parameters.cake
@@ -17,6 +17,7 @@ public static class IntelliJBuildParameters
     public static IntelliJBuildTasks Tasks { get; private set; }
     public static IntelliJBuildPaths Paths { get; private set; }
     public static bool ShouldRunPluginVerifier { get; private set; }
+    public static string[] IntelliJAnalyzerTasks { get; private set; }
     static IntelliJBuildParameters()
     {
         Tasks = new IntelliJBuildTasks();
@@ -40,6 +41,7 @@ public static class IntelliJBuildParameters
         context.Information("PluginChannelGradleProperty: {0}", PluginChannelGradleProperty);
         context.Information("PluginVersionGradleProperty: {0}", PluginVersionGradleProperty);
         context.Information("ShouldRunPluginVerifier: {0}", ShouldRunPluginVerifier);
+        context.Information("IntelliJAnalyzerTasks: {0}", string.Join(", ", IntelliJAnalyzerTasks));
     }
 
     public static void SetParameters(
@@ -121,7 +123,8 @@ public static class IntelliJBuildParameters
         GradleLogLevel gradleVerbosity = GradleLogLevel.Default,
         DirectoryPath pluginBuildOutputPath = null,
         DirectoryPath pluginPackOutputPath = null,
-        bool shouldRunPluginVerifier = true
+        bool shouldRunPluginVerifier = true,
+        string[] intelliJAnalyzerTasks = null
         )
     {
         if (context == null)
@@ -231,5 +234,6 @@ public static class IntelliJBuildParameters
         PluginVersionGradleProperty = pluginVersionGradleProperty;
         Paths = IntelliJBuildPaths.GetPaths(context);
         ShouldRunPluginVerifier = shouldRunPluginVerifier;
+        IntelliJAnalyzerTasks = intelliJAnalyzerTasks ?? new[] { "detekt", "ktlintCheck", "verifyPlugin" };
     }
 }


### PR DESCRIPTION
which defaults to the previously fixed tasks:
{ "detekt", "ktlintCheck", "verifyPlugin" }

fixes #119 